### PR TITLE
fix h_caption_loqs_label

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -84,6 +84,9 @@ h_identify_loq_values <- function(loqs_data) {
 h_caption_loqs_label <- function(loqs_data) {
   loq_values <- h_identify_loq_values(loqs_data)
 
+  loq_values$LLOQC <- ifelse(is.na(loq_values$LLOQC), "NA", loq_values$LLOQC)
+  loq_values$ULOQC <- ifelse(is.na(loq_values$ULOQC), "NA", loq_values$ULOQC)
+
   # create caption
   caption_loqs_label <- paste0(
     "Limits of quantification read from study data for ",

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,26 +84,14 @@ h_identify_loq_values <- function(loqs_data) {
 h_caption_loqs_label <- function(loqs_data) {
   loq_values <- h_identify_loq_values(loqs_data)
 
-  if (is.na(loq_values$LLOQC)) {
-    lloq_value <- "NA"
-  } else {
-    lloq_value <- loq_values$LLOQC
-  }
-
-  if (is.na(loq_values$ULOQC)) {
-    uloq_value <- "NA"
-  } else {
-    uloq_value <- loq_values$ULOQC
-  }
-
   # create caption
   caption_loqs_label <- paste0(
     "Limits of quantification read from study data for ",
     loqs_data$PARAM,
     ": LLOQ is ",
-    lloq_value,
+    loq_values$LLOQC,
     ", ULOQ is ",
-    uloq_value
+    loq_values$ULOQC
   )
 
   return(caption_loqs_label)

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,17 +84,17 @@ h_identify_loq_values <- function(loqs_data) {
 h_caption_loqs_label <- function(loqs_data) {
   loq_values <- h_identify_loq_values(loqs_data)
 
-  loq_values$LLOQC <- ifelse(is.na(loq_values$LLOQC), "NA", loq_values$LLOQC)
-  loq_values$ULOQC <- ifelse(is.na(loq_values$ULOQC), "NA", loq_values$ULOQC)
+  lloqc <- ifelse(is.na(loq_values$LLOQC), "NA", loq_values$LLOQC)
+  uloqc <- ifelse(is.na(loq_values$ULOQC), "NA", loq_values$ULOQC)
 
   # create caption
   caption_loqs_label <- paste0(
     "Limits of quantification read from study data for ",
     loqs_data$PARAM,
     ": LLOQ is ",
-    loq_values$LLOQC,
+    lloqc,
     ", ULOQ is ",
-    loq_values$ULOQC
+    uloqc
   )
 
   return(caption_loqs_label)


### PR DESCRIPTION
FYI @npaszty 

So this fixes the breaking example :

```
library(scda)
ADLB <- synthetic_cdisc_data("latest")$adlb
caption_label <- goshawk:::h_caption_loqs_label(loqs_data = ADLB)
``` 

So  the output of `loq_values <- h_identify_loq_values(loqs_data)` seems to be a data.frame and if there's more than one row the check `if (is.na(loq_values$LLOQC)) {` gives an error so I'm now looking entry by entry to convert NA to "NA".


