### PR TITLE
Adding rmarkdown to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,4 +57,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,8 @@ Suggests:
     scda (>= 0.1.5),
     scda.2022 (>= 0.1.3),
     testthat (>= 2.0),
-    tidyr
+    tidyr,
+    rmarkdown
 VignetteBuilder:
     knitr
 Remotes:


### PR DESCRIPTION
I got error:
```
error: processing vignette 'goshawk.Rmd' failed with diagnostics:
The 'rmarkdown' package should be installed and declared as a dependency of the 'goshawk' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'rmarkdown' package.
```