### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Imports:
 Suggests:
     knitr (>= 1.42),
     nestcolor (>= 0.1.0),
-    rmarkdown (>= 1.11),
+    rmarkdown (>= 2.23),
     testthat (>= 3.0.4),
     tidyr
 VignetteBuilder:


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.