### PR TITLE
241: adding parameter to adjust dot size.

### DIFF
--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -29,7 +29,7 @@
 #' Default value is `ggplot2::waiver()`.
 #' @param rotate_xlab boolean whether to rotate x-axis labels.
 #' @param plot_font_size control font size for title, x-axis, y-axis and legend font.
-#' @param dot_size plot dot size.
+#' @param dot_size plot dot size. Default to 3.
 #' @param dodge control position dodge.
 #' @param plot_height height of produced plot. 989 pixels by default.
 #' @param count_threshold \code{integer} minimum number observations needed to show the appropriate
@@ -208,7 +208,8 @@
 #'   xtick = c(0, 1, 5),
 #'   xlabel = c("Baseline", "Week 1", "Week 5"),
 #'   rotate_xlab = FALSE,
-#'   plot_height = 1500
+#'   plot_height = 1500,
+#'   dot_size = 1
 #' )
 #'
 #' g_lineplot(
@@ -228,7 +229,8 @@
 #'   xtick = c(0, 1, 5),
 #'   xlabel = c("Baseline", "Week 1", "Week 5"),
 #'   rotate_xlab = FALSE,
-#'   plot_height = 1500
+#'   plot_height = 1500,
+#'   dot_size = 4
 #' )
 g_lineplot <- function(label = "Line Plot",
                        data,

--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -29,6 +29,7 @@
 #' Default value is `ggplot2::waiver()`.
 #' @param rotate_xlab boolean whether to rotate x-axis labels.
 #' @param plot_font_size control font size for title, x-axis, y-axis and legend font.
+#' @param dot_size plot dot size.
 #' @param dodge control position dodge.
 #' @param plot_height height of produced plot. 989 pixels by default.
 #' @param count_threshold \code{integer} minimum number observations needed to show the appropriate
@@ -254,6 +255,7 @@ g_lineplot <- function(label = "Line Plot",
                        xlabel = xtick,
                        rotate_xlab = FALSE,
                        plot_font_size = 12,
+                       dot_size = 3,
                        dodge = 0.4,
                        plot_height = 989,
                        count_threshold = 0,
@@ -405,7 +407,7 @@ g_lineplot <- function(label = "Line Plot",
       )
     ) +
       ggplot2::theme_bw() +
-      ggplot2::geom_point(position = pd) +
+      ggplot2::geom_point(position = pd, size = dot_size) +
       ggplot2::scale_color_manual(
         values = color_manual, name = trt_label, guide = ggplot2::guide_legend(ncol = 3, order = 1)
       ) +
@@ -443,7 +445,7 @@ g_lineplot <- function(label = "Line Plot",
       ggplot2::scale_linetype_manual(" ", values = type_mapping, guide = ggplot2::guide_legend(ncol = 3, order = 1)) +
       ggplot2::scale_shape_manual(" ", values = shape_mapping, guide = ggplot2::guide_legend(ncol = 3, order = 1)) +
       ggplot2::theme(legend.key.size = grid::unit(1, "cm")) +
-      ggplot2::geom_point(position = pd, size = 3)
+      ggplot2::geom_point(position = pd, size = dot_size)
   }
 
   plot1 <- plot1 +

--- a/R/g_spaghettiplot.R
+++ b/R/g_spaghettiplot.R
@@ -30,6 +30,7 @@
 #'  value is `ggplot2::waiver()`.
 #' @param rotate_xlab boolean whether to rotate x-axis labels.
 #' @param font_size control font size for title, x-axis, y-axis and legend font.
+#' @param dot_size plot dot size.
 #' @param group_stats control group mean or median overlay.
 #' @param hline_arb ('numeric vector') value identifying intercept for arbitrary horizontal lines.
 #' @param hline_arb_color ('character vector') optional, color for the arbitrary horizontal lines.
@@ -233,6 +234,7 @@ g_spaghettiplot <- function(data,
                             xlabel = xtick,
                             rotate_xlab = FALSE,
                             font_size = 12,
+                            dot_size = 2,
                             group_stats = "NONE",
                             hline_arb = numeric(0),
                             hline_arb_color = "red",
@@ -288,7 +290,7 @@ g_spaghettiplot <- function(data,
     data = plot_data,
     ggplot2::aes(x = !!sym(time), y = !!sym(value_var), color = !!sym(trt_group), group = !!sym(subj_id))
   ) +
-    ggplot2::geom_point(size = 0.8, na.rm = TRUE, ggplot2::aes(shape = !!sym(loq_flag_var))) +
+    ggplot2::geom_point(size = dot_size, na.rm = TRUE, ggplot2::aes(shape = !!sym(loq_flag_var))) +
     ggplot2::geom_line(linewidth = 0.4, alpha = alpha, na.rm = TRUE) +
     ggplot2::facet_wrap(trt_group, ncol = facet_ncol, scales = facet_scales) +
     ggplot2::labs(caption = caption_loqs_label) +

--- a/R/g_spaghettiplot.R
+++ b/R/g_spaghettiplot.R
@@ -30,7 +30,7 @@
 #'  value is `ggplot2::waiver()`.
 #' @param rotate_xlab boolean whether to rotate x-axis labels.
 #' @param font_size control font size for title, x-axis, y-axis and legend font.
-#' @param dot_size plot dot size.
+#' @param dot_size plot dot size. Default to 2.
 #' @param group_stats control group mean or median overlay.
 #' @param hline_arb ('numeric vector') value identifying intercept for arbitrary horizontal lines.
 #' @param hline_arb_color ('character vector') optional, color for the arbitrary horizontal lines.
@@ -146,7 +146,8 @@
 #'   group_stats = "median",
 #'   hline_arb = 1.3,
 #'   hline_vars = c("ANRHI", "ANRLO", "ULOQN", "LLOQN"),
-#'   hline_vars_colors = c("pink", "brown", "purple", "gray")
+#'   hline_vars_colors = c("pink", "brown", "purple", "gray"),
+#'   dot_size = 3
 #' )
 #'
 #' g_spaghettiplot(
@@ -167,7 +168,8 @@
 #'   hline_arb = c(.5, .7, 1),
 #'   hline_arb_color = c("blue", "red", "green"),
 #'   hline_arb_label = c("Arb_Hori_line_A", "Arb_Hori_line_B", "Arb_Hori_line_C"),
-#'   hline_vars = c("ANRHI", "ANRLO")
+#'   hline_vars = c("ANRHI", "ANRLO"),
+#'   dot_size = 4
 #' )
 #'
 #' # removing missing levels from the plot with facet_scales
@@ -209,7 +211,8 @@
 #'   hline_arb = c(.5, .7, 1),
 #'   hline_arb_color = c("blue", "red", "green"),
 #'   hline_arb_label = c("Arb_Hori_line_A", "Arb_Hori_line_B", "Arb_Hori_line_C"),
-#'   hline_vars = c("ANRHI", "ANRLO")
+#'   hline_vars = c("ANRHI", "ANRLO"),
+#'   dot_size = 1
 #' )
 #'
 g_spaghettiplot <- function(data,

--- a/man/g_lineplot.Rd
+++ b/man/g_lineplot.Rd
@@ -30,6 +30,7 @@ g_lineplot(
   xlabel = xtick,
   rotate_xlab = FALSE,
   plot_font_size = 12,
+  dot_size = 3,
   dodge = 0.4,
   plot_height = 989,
   count_threshold = 0,
@@ -91,6 +92,8 @@ Default value is \code{ggplot2::waiver()}.}
 \item{rotate_xlab}{boolean whether to rotate x-axis labels.}
 
 \item{plot_font_size}{control font size for title, x-axis, y-axis and legend font.}
+
+\item{dot_size}{plot dot size.}
 
 \item{dodge}{control position dodge.}
 

--- a/man/g_lineplot.Rd
+++ b/man/g_lineplot.Rd
@@ -93,7 +93,7 @@ Default value is \code{ggplot2::waiver()}.}
 
 \item{plot_font_size}{control font size for title, x-axis, y-axis and legend font.}
 
-\item{dot_size}{plot dot size.}
+\item{dot_size}{plot dot size. Default to 3.}
 
 \item{dodge}{control position dodge.}
 
@@ -276,7 +276,8 @@ g_lineplot(
   xtick = c(0, 1, 5),
   xlabel = c("Baseline", "Week 1", "Week 5"),
   rotate_xlab = FALSE,
-  plot_height = 1500
+  plot_height = 1500,
+  dot_size = 1
 )
 
 g_lineplot(
@@ -296,7 +297,8 @@ g_lineplot(
   xtick = c(0, 1, 5),
   xlabel = c("Baseline", "Week 1", "Week 5"),
   rotate_xlab = FALSE,
-  plot_height = 1500
+  plot_height = 1500,
+  dot_size = 4
 )
 }
 \author{

--- a/man/g_spaghettiplot.Rd
+++ b/man/g_spaghettiplot.Rd
@@ -27,6 +27,7 @@ g_spaghettiplot(
   xlabel = xtick,
   rotate_xlab = FALSE,
   font_size = 12,
+  dot_size = 2,
   group_stats = "NONE",
   hline_arb = numeric(0),
   hline_arb_color = "red",
@@ -86,6 +87,8 @@ value is \code{ggplot2::waiver()}.}
 \item{rotate_xlab}{boolean whether to rotate x-axis labels.}
 
 \item{font_size}{control font size for title, x-axis, y-axis and legend font.}
+
+\item{dot_size}{plot dot size.}
 
 \item{group_stats}{control group mean or median overlay.}
 

--- a/man/g_spaghettiplot.Rd
+++ b/man/g_spaghettiplot.Rd
@@ -88,7 +88,7 @@ value is \code{ggplot2::waiver()}.}
 
 \item{font_size}{control font size for title, x-axis, y-axis and legend font.}
 
-\item{dot_size}{plot dot size.}
+\item{dot_size}{plot dot size. Default to 2.}
 
 \item{group_stats}{control group mean or median overlay.}
 
@@ -210,7 +210,8 @@ g_spaghettiplot(
   group_stats = "median",
   hline_arb = 1.3,
   hline_vars = c("ANRHI", "ANRLO", "ULOQN", "LLOQN"),
-  hline_vars_colors = c("pink", "brown", "purple", "gray")
+  hline_vars_colors = c("pink", "brown", "purple", "gray"),
+  dot_size = 3
 )
 
 g_spaghettiplot(
@@ -231,7 +232,8 @@ g_spaghettiplot(
   hline_arb = c(.5, .7, 1),
   hline_arb_color = c("blue", "red", "green"),
   hline_arb_label = c("Arb_Hori_line_A", "Arb_Hori_line_B", "Arb_Hori_line_C"),
-  hline_vars = c("ANRHI", "ANRLO")
+  hline_vars = c("ANRHI", "ANRLO"),
+  dot_size = 4
 )
 
 # removing missing levels from the plot with facet_scales
@@ -273,7 +275,8 @@ g_spaghettiplot(
   hline_arb = c(.5, .7, 1),
   hline_arb_color = c("blue", "red", "green"),
   hline_arb_label = c("Arb_Hori_line_A", "Arb_Hori_line_B", "Arb_Hori_line_C"),
-  hline_vars = c("ANRHI", "ANRLO")
+  hline_vars = c("ANRHI", "ANRLO"),
+  dot_size = 1
 )
 
 }


### PR DESCRIPTION
Fixes https://github.com/insightsengineering/goshawk/issues/241

I have added dot_size as a parameter to adjust the size and default to 3. 

<details>
<summary>goshawk examples</summary>

```r
pkgload::load_all("goshawk")
library(stringr)

# original ARM value = dose value
arm_mapping <- list(
  "A: Drug X" = "150mg QD", "B: Placebo" = "Placebo", "C: Combination" = "Combination"
)
color_manual <- c("150mg QD" = "#000000", "Placebo" = "#3498DB", "Combination" = "#E74C3C")

ADLB <- rADLB
var_labels <- lapply(ADLB, function(x) attributes(x)$label)
ADLB <- ADLB %>%
  mutate(AVISITCD = case_when(
    AVISIT == "SCREENING" ~ "SCR",
    AVISIT == "BASELINE" ~ "BL",
    grepl("WEEK", AVISIT) ~
      paste(
        "W",
        trimws(
          substr(
            AVISIT,
            start = 6,
            stop = str_locate(AVISIT, "DAY") - 1
          )
        )
      ),
    TRUE ~ NA_character_
  )) %>%
  mutate(AVISITCDN = case_when(
    AVISITCD == "SCR" ~ -2,
    AVISITCD == "BL" ~ 0,
    grepl("W", AVISITCD) ~ as.numeric(gsub("\\D+", "", AVISITCD)),
    TRUE ~ NA_real_
  )) %>%
  # use ARMCD values to order treatment in visualization legend
  mutate(TRTORD = ifelse(grepl("C", ARMCD), 1,
    ifelse(grepl("B", ARMCD), 2,
      ifelse(grepl("A", ARMCD), 3, NA)
    )
  )) %>%
  mutate(ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))])) %>%
  mutate(ARM = factor(ARM) %>%
    reorder(TRTORD)) %>%
  mutate(ANRLO = .5, ANRHI = 1) %>%
  rowwise() %>%
  group_by(PARAMCD) %>%
  mutate(LBSTRESC = ifelse(USUBJID %in% sample(USUBJID, 1, replace = TRUE),
    paste("<", round(runif(1, min = .5, max = .7))), LBSTRESC
  )) %>%
  mutate(LBSTRESC = ifelse(USUBJID %in% sample(USUBJID, 1, replace = TRUE),
    paste(">", round(runif(1, min = .9, max = 1.2))), LBSTRESC
  )) %>%
  ungroup()
attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
attr(ADLB[["ANRLO"]], "label") <- "Analysis Normal Range Lower Limit"
attr(ADLB[["ANRHI"]], "label") <- "Analysis Normal Range Upper Limit"

# add LLOQ and ULOQ variables
ADLB_LOQS <- goshawk:::h_identify_loq_values(ADLB, "LOQFL")
ADLB <- left_join(ADLB, ADLB_LOQS, by = "PARAM")

g_spaghettiplot(
  data = ADLB,
  subj_id = "USUBJID",
  biomarker_var = "PARAMCD",
  biomarker = "CRP",
  value_var = "AVAL",
  trt_group = "ARM",
  time = "AVISITCD",
  color_manual = color_manual,
  color_comb = "#39ff14",
  alpha = .02,
  xtick = c("BL", "W 1", "W 4"),
  xlabel = c("Baseline", "Week 1", "Week 4"),
  rotate_xlab = FALSE,
  group_stats = "median",
  hline_vars = c("ANRHI", "ANRLO"),
  hline_vars_colors = c("pink", "brown"),
dot_size = 2
)

g_spaghettiplot(
  data = ADLB,
  subj_id = "USUBJID",
  biomarker_var = "PARAMCD",
  biomarker = "CRP",
  value_var = "AVAL",
  trt_group = "ARM",
  time = "AVISITCD",
  color_manual = color_manual,
  color_comb = "#39ff14",
  alpha = .02,
  xtick = c("BL", "W 1", "W 4"),
  xlabel = c("Baseline", "Week 1", "Week 4"),
  rotate_xlab = FALSE,
  group_stats = "median",
  hline_arb = 1.3,
  hline_vars = c("ANRHI", "ANRLO", "ULOQN", "LLOQN"),
  hline_vars_colors = c("pink", "brown", "purple", "gray"),
dot_size = 5
)
```

</details>
