### PR TITLE
Change automated label on `g_spaghettiplot `

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,4 +60,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/g_spaghettiplot.R
+++ b/R/g_spaghettiplot.R
@@ -324,7 +324,7 @@ g_spaghettiplot <- function(data,
     }
     plot <- plot +
       ggplot2::geom_line(
-        ggplot2::aes(x = !!sym(time), y = .data$AGG_VAL, group = 1, linetype = metric),
+        ggplot2::aes(x = !!sym(time), y = .data$AGG_VAL, group = 1, linetype =.data$metric),
         data = plot_data_groupped,
         lwd = 1,
         color = color_comb,

--- a/R/g_spaghettiplot.R
+++ b/R/g_spaghettiplot.R
@@ -324,7 +324,7 @@ g_spaghettiplot <- function(data,
     }
     plot <- plot +
       ggplot2::geom_line(
-        ggplot2::aes(x = !!sym(time), y = .data$AGG_VAL, group = 1, linetype =.data$metric),
+        ggplot2::aes(x = !!sym(time), y = .data$AGG_VAL, group = 1, linetype = .data$metric),
         data = plot_data_groupped,
         lwd = 1,
         color = color_comb,

--- a/R/g_spaghettiplot.R
+++ b/R/g_spaghettiplot.R
@@ -324,7 +324,7 @@ g_spaghettiplot <- function(data,
     }
     plot <- plot +
       ggplot2::geom_line(
-        ggplot2::aes(x = !!sym(time), y = .data$AGG_VAL, group = 1, linetype = "metric"),
+        ggplot2::aes(x = !!sym(time), y = .data$AGG_VAL, group = 1, linetype = metric),
         data = plot_data_groupped,
         lwd = 1,
         color = color_comb,


### PR DESCRIPTION
This fixes issue detected in Theory app on GitLab.

<img width="89" alt="image" src="https://github.com/user-attachments/assets/fe6e4a43-da53-4588-9b84-804c72ce8c36">

On legend, currently we display `metric` phrase instead of `Mean` or `Median`. With this fix we display actual statistic name

<details><summary>Tested with</summary>

```r
library(stringr)

# original ARM value = dose value
arm_mapping <- list(
  "A: Drug X" = "150mg QD", "B: Placebo" = "Placebo", "C: Combination" = "Combination"
)
color_manual <- c("150mg QD" = "#000000", "Placebo" = "#3498DB", "Combination" = "#E74C3C")

ADLB <- rADLB
var_labels <- lapply(ADLB, function(x) attributes(x)$label)
ADLB <- ADLB %>%
  mutate(AVISITCD = case_when(
    AVISIT == "SCREENING" ~ "SCR",
    AVISIT == "BASELINE" ~ "BL",
    grepl("WEEK", AVISIT) ~
      paste(
        "W",
        trimws(
          substr(
            AVISIT,
            start = 6,
            stop = str_locate(AVISIT, "DAY") - 1
          )
        )
      ),
    TRUE ~ NA_character_
  )) %>%
  mutate(AVISITCDN = case_when(
    AVISITCD == "SCR" ~ -2,
    AVISITCD == "BL" ~ 0,
    grepl("W", AVISITCD) ~ as.numeric(gsub("\\D+", "", AVISITCD)),
    TRUE ~ NA_real_
  )) %>%
  # use ARMCD values to order treatment in visualization legend
  mutate(TRTORD = ifelse(grepl("C", ARMCD), 1,
                         ifelse(grepl("B", ARMCD), 2,
                                ifelse(grepl("A", ARMCD), 3, NA)
                         )
  )) %>%
  mutate(ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))])) %>%
  mutate(ARM = factor(ARM) %>%
           reorder(TRTORD)) %>%
  mutate(ANRLO = .5, ANRHI = 1) %>%
  rowwise() %>%
  group_by(PARAMCD) %>%
  mutate(LBSTRESC = ifelse(USUBJID %in% sample(USUBJID, 1, replace = TRUE),
                           paste("<", round(runif(1, min = .5, max = .7))), LBSTRESC
  )) %>%
  mutate(LBSTRESC = ifelse(USUBJID %in% sample(USUBJID, 1, replace = TRUE),
                           paste(">", round(runif(1, min = .9, max = 1.2))), LBSTRESC
  )) %>%
  ungroup()
attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
attr(ADLB[["ANRLO"]], "label") <- "Analysis Normal Range Lower Limit"
attr(ADLB[["ANRHI"]], "label") <- "Analysis Normal Range Upper Limit"

# add LLOQ and ULOQ variables
ADLB_LOQS <- goshawk:::h_identify_loq_values(ADLB, "LOQFL")
ADLB <- left_join(ADLB, ADLB_LOQS, by = "PARAM")

g_spaghettiplot(
  data = ADLB,
  subj_id = "USUBJID",
  biomarker_var = "PARAMCD",
  biomarker = "CRP",
  value_var = "AVAL",
  trt_group = "ARM",
  time = "AVISITCD",
  color_manual = color_manual,
  color_comb = "#39ff14",
  alpha = .02,
  xtick = c("BL", "W 1", "W 4"),
  xlabel = c("Baseline", "Week 1", "Week 4"),
  rotate_xlab = FALSE,
  group_stats = "MEAN",
  hline_vars = c("ANRHI", "ANRLO"),
  hline_vars_colors = c("pink", "brown")
)
```

</details>

<img width="386" alt="Mean" src="https://github.com/user-attachments/assets/20a1d8a5-0995-449a-af8c-bed330c309ad">

<img width="385" alt="Median" src="https://github.com/user-attachments/assets/17acf5d0-aea3-4059-b9b6-3069ad41d9cd">
