### PR TITLE
Remove lookup-refs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -40,8 +40,6 @@ jobs:
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/nestcolor
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
     uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
@@ -63,8 +61,6 @@ jobs:
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/nestcolor
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
@@ -74,8 +70,6 @@ jobs:
       additional-env-vars: |
         NOT_CRAN=true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/nestcolor
   linter:
     if: github.event_name != 'push'
     name: SuperLinter 🦸‍♀️
@@ -88,8 +82,6 @@ jobs:
     with:
       auto-update: true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/nestcolor
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,5 +43,3 @@ jobs:
       default-landing-page: latest-tag
       additional-unit-test-report-directories: unit-test-report-non-cran
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/nestcolor

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,8 +17,6 @@ jobs:
     with:
       default-landing-page: latest-tag
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/nestcolor
   validation:
     name: R Package Validation report 📃
     needs: release
@@ -27,8 +25,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/nestcolor
   release:
     name: Create release 🎉
     uses: insightsengineering/r.pkg.template/.github/workflows/release.yaml@main
@@ -52,8 +48,6 @@ jobs:
         checking Rd line widths .* NOTE
         checking top-level files .* NOTE
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/nestcolor
   coverage:
     name: Coverage 📔
     needs: [release, docs]
@@ -64,8 +58,6 @@ jobs:
       additional-env-vars: |
         NOT_CRAN=true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/nestcolor
   wasm:
     name: Build WASM packages 🧑‍🏭
     needs: release

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -58,9 +58,6 @@ jobs:
       )
     name: revdepcheck ↩️
     uses: insightsengineering/r.pkg.template/.github/workflows/revdepcheck.yaml@main
-    with:
-      lookup-refs: |
-        insightsengineering/nestcolor
   rhub:
     if: >
       github.event_name == 'schedule' || (
@@ -69,6 +66,3 @@ jobs:
       )
     name: R-hub 🌐
     uses: insightsengineering/r.pkg.template/.github/workflows/rhub.yaml@main
-    with:
-      lookup-refs: |
-        insightsengineering/nestcolor


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/609

From now on, we will provide development dependencies in 
```
Remotes: repo/project@branch
```
format, so it's explicitly visible in the DESCRIPTION file and can be handled by `pak::install`, `renv::install` and `remotes::install`.

With development dependencies specified in CJ Pipelines configuration, this connection was hidden, and it was hard to install the package from the main branch (or any other branch) locally from user's machine.